### PR TITLE
Make home.nix CPU/username agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 Create symbolic links to the dotfiles in this repo.
 
 ```bash
+cd ~
+git clone https://github.com/neet/dotfiles.git
+cd dotfiles
 make init
 ```
 
@@ -12,6 +15,7 @@ Install Nix and Home Manager.
 
 ```
 sh <(curl -L https://nixos.org/nix/install) --daemon
+cd ~/.config/home-manager
 nix run home-manager/release-23.05 -- switch
 ```
 
@@ -19,6 +23,7 @@ Install Homebrew packages
 
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+cd ~/
 brew bundle install
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,8 @@
   };
 
   outputs = { self, nixpkgs, home-manager }: {
-    homeConfigurations."neet" = home-manager.lib.homeManagerConfiguration {
-      inherit (nixpkgs.legacyPackages.aarch64-darwin) pkgs;
+    homeConfigurations."ryo.igarashi" = home-manager.lib.homeManagerConfiguration {
+      inherit (nixpkgs.legacyPackages.x86_64-darwin) pkgs;
       modules = [ ./home.nix ];
     };
   };

--- a/home.nix
+++ b/home.nix
@@ -5,6 +5,7 @@
   home.username = "ryo.igarashi";
   home.homeDirectory = "/Users/ryo.igarashi";
   home.language.base = "en_GB.UTF-8";
+  home.enableNixpkgsReleaseCheck = true;
 
   home.packages = [
     pkgs.ack

--- a/home.nix
+++ b/home.nix
@@ -2,8 +2,8 @@
 
 {
   home.stateVersion = "23.05";
-  home.username = "neet";
-  home.homeDirectory = "/Users/neet";
+  home.username = "ryo.igarashi";
+  home.homeDirectory = "/Users/ryo.igarashi";
   home.language.base = "en_GB.UTF-8";
 
   home.packages = [


### PR DESCRIPTION
- usernameとアーキテクチャを動的に決定したい
- flake系のファイルをコミットしなくても使えるようにしたい。
  - 差分検出にgitを使わないといけないのはしょうがないらしく、仕方なくghqのorgのほうのディレクトリにflakeを作っている。
  - 組織全体でバイナリを共有する形にはなっている